### PR TITLE
Allow multiple commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ npm install octokit-commit-multiple-files --save
 
 ## Usage
 
-This plugin accepts `owner`, `repo`, `path`, `branch` and `message` like `.createOrUpdateFile` ([Octokit Docs](https://octokit.github.io/rest.js/#octokit-routes-repos-create-or-update-file)).
+This plugin accepts `owner`, `repo`, `path` and `branch` like `.createOrUpdateFile` ([Octokit Docs](https://octokit.github.io/rest.js/#octokit-routes-repos-create-or-update-file)).
 
 If the `branch` provided does not exist, the plugin will error. To automatically create it, set `createBranch` to true. You may provide a `base` branch if you choose to do this, or the plugin will use the repo's default branch as the base.
 
-In addition, it accepts `changes` which is an array of objects containing a `path` and the file `contents`.
+In addition, it accepts `changes` which is an array of objects containing a `message` and a `files` object
 
 ```javascript
 const Octokit = require("@octokit/rest").plugin(
@@ -27,17 +27,39 @@ const branchName = await octokit.repos.createOrUpdateFiles({
   repo,
   branch,
   createBranch,
-  message,
   changes: [
     {
-      path: "test.md",
-      contents: "One"
+      message: "Your commit message",
+      files: {
+        "test.md": `# This is a test
+
+I hope it works`,
+        "test2.md": {
+          contents: `Something else`
+        }
+      }
     },
     {
-      path: "test2.md",
-      contents: "Two"
+      "message": "This is a separate commit",
+      "files": {
+        "second.md": "Where should we go today?"
+      }
     }
   ]
 })
 ```
 
+In addition, you can set the `mode` of a file change. For example, if you wanted to update a submodule pointer:
+
+```javascript
+{
+  "message": "This is a submodule commit",
+  "files": {
+    "my_submodule": {
+      "contents": "your-commit-sha",
+      "mode": "160000",
+      "type": "commit"
+    }
+  }
+}
+```

--- a/create-or-update-files.js
+++ b/create-or-update-files.js
@@ -56,7 +56,6 @@ module.exports = function(octokit, opts) {
       }
 
       // Create blobs
-      const treeItems = [];
       for (let change of changes) {
         let message = change.message;
         if (!message) {
@@ -66,6 +65,7 @@ module.exports = function(octokit, opts) {
           return reject(`changes[].files is a required parameter`);
         }
 
+        const treeItems = [];
         for (let fileName in change.files) {
           let properties = change.files[fileName] || "";
 

--- a/create-or-update-files.js
+++ b/create-or-update-files.js
@@ -71,25 +71,32 @@ module.exports = function(octokit, opts) {
 
           let contents = properties.contents || properties;
           let mode = properties.mode || "100644";
+          let type = properties.type || "blob";
 
           if (!contents) {
             return reject(`No file contents provided for ${fileName}`);
           }
 
-          let file = (
-            await octokit.git.createBlob({
-              owner,
-              repo,
-              content: Buffer.from(contents).toString("base64"),
-              encoding: "base64"
-            })
-          ).data;
+          let fileSha;
+          if (type == "commit") {
+            fileSha = contents;
+          } else {
+            let file = (
+              await octokit.git.createBlob({
+                owner,
+                repo,
+                content: Buffer.from(contents).toString("base64"),
+                encoding: "base64"
+              })
+            ).data;
+            fileSha = file.sha;
+          }
 
           treeItems.push({
             path: fileName,
-            sha: file.sha,
+            sha: fileSha,
             mode: mode,
-            type: "blob"
+            type: type
           });
         }
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "octokit-commit-multiple-files",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Octokit plugin to create/update multiple files at once",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint *.js",
+    "lint-fix": "eslint --fix *.js"
   },
   "keywords": [
     "github",


### PR DESCRIPTION
Update to `v3.0.0` to allow a new signature for `changes` as discussed in https://twitter.com/mheap/status/1219260814164680704

Proposed new format:

```javascript
const branchName = await octokit.repos.createOrUpdateFiles({
  owner,
  repo,
  branch,
  createBranch,
  changes: [
    {
      message: "Your commit message",
      files: {
        "test.md": `# This is a test

I hope it works`,
        "test2.md": {
          contents: `Something else`
        }
      }
    },
    {
      "message": "This is a separate commit",
      "files": {
        "second.md": "Where should we go today?"
      }
    }
  ]
})
```

And to commit a submodule:

```
const branchName = await octokit.repos.createOrUpdateFiles({
  owner,
  repo,
  branch,
  createBranch,
  changes: [
    {
      "message": "This is a submodule commit",
      "files": {
        "my_submodule": {
          "contents": "your-commit-sha",
          "mode": "160000",
          "type": "commit"
        }
      }
    }
  ]
})
```