### PR TITLE
Add `filesToDelete` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In addition, you can set the `filesToDelete` property as an array of strings (fi
 
 ```javascript
 {
-  "message": "This is a submodule commit",
+  "message": "This commit removes files",
   "filesToDelete": ['path/to/my/file.txt', 'path/to/another.js'],
 }
 ```
@@ -80,7 +80,7 @@ In addition, you can set the `filesToDelete` property as an array of strings (fi
 
 ```javascript
 {
-  "message": "This is a submodule commit",
+  "message": "This commit removes files",
   "filesToDelete": ['path/to/my/file.txt', 'path/to/another.js'],
   "ignoreDeletionFailures": true,
 }

--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ In addition, you can set the `filesToDelete` property as an array of strings (fi
 }
 ```
 
-Note that the `ignoreDeletionFailures` property is set to false by default (works in a context of a single change).
-If `ignoreDeletionFailures` is set to false, an error will be thrown if any file set for deletion is missing and the commit will be discarded.
-If `ignoreDeletionFailures` is set to true, missing files that are set for deletion will be ignored.
+- Note that the `ignoreDeletionFailures` property is set to false by default (works in a context of a single change).
+- If `ignoreDeletionFailures` is set to false, an error will be thrown if any file set for deletion is missing and the commits will stop processing. Any commits made before this will still be applied. Any changes in this `change` will not be committed. No future changes will be applied.
+- If `ignoreDeletionFailures` is set to true, missing files that are set for deletion will be ignored.
+- If a file is created and deleted in the same `change`, the file will be created/updated
 
 ```javascript
 {

--- a/README.md
+++ b/README.md
@@ -63,3 +63,24 @@ In addition, you can set the `mode` of a file change. For example, if you wanted
   }
 }
 ```
+
+In addition, you can set the `filesToDelete` property as an array of strings (file paths) to set files for deletion in a single commit (works with updates and creations).
+
+```javascript
+{
+  "message": "This is a submodule commit",
+  "filesToDelete": ['path/to/my/file.txt', 'path/to/another.js'],
+}
+```
+
+Note that the `ignoreDeletionFailures` property is set to false by default (works in a context of a single change).
+If `ignoreDeletionFailures` is set to false, an error will be thrown if any file set for deletion is missing and the commit will be discarded.
+If `ignoreDeletionFailures` is set to true, missing files that are set for deletion will be ignored.
+
+```javascript
+{
+  "message": "This is a submodule commit",
+  "filesToDelete": ['path/to/my/file.txt', 'path/to/another.js'],
+  "ignoreDeletionFailures": true,
+}
+```

--- a/create-or-update-files.js
+++ b/create-or-update-files.js
@@ -88,13 +88,15 @@ module.exports = function (octokit, opts) {
           });
         }
 
-        for (const fileName of change.filesToDelete) {
-          treeItems.push({
-            path: fileName,
-            sha: null, // sha as null implies that the file should be deleted
-            mode: "100644",
-            type: "commit"
-          });
+        if (Array.isArray(change.filesToDelete)) {
+          for (const fileName of change.filesToDelete) {
+            treeItems.push({
+              path: fileName,
+              sha: null, // sha as null implies that the file should be deleted
+              mode: "100644",
+              type: "commit"
+            });
+          }
         }
 
         // Add those blobs to a tree

--- a/create-or-update-files.js
+++ b/create-or-update-files.js
@@ -62,7 +62,7 @@ module.exports = function (octokit, opts) {
           return reject(`changes[].message is a required parameter`);
         }
 
-        if ((!change.files || Object.keys(change.files).length === 0) && change.filesToDelete.length === 0) {
+        if ((!change.files || Object.keys(change.files).length === 0) && (!change.filesToDelete || change.filesToDelete.length === 0)) {
           return reject(`either changes[].files or changes[].filesToDelete are required`);
         }
 
@@ -194,7 +194,6 @@ async function loadRef(octokit, owner, repo, ref) {
       repo,
       ref: `heads/${ref}`
     })
-    console.log(x);
     return x.data.object.sha
   } catch (e) {
     // console.log(e);

--- a/create-or-update-files.test.js
+++ b/create-or-update-files.test.js
@@ -31,7 +31,7 @@ I hope it works`,
 };
 
 // Destructuring for easier access later
-let { owner, repo, base, branch, createBranch, changes } = validRequest;
+let { owner, repo, base, branch } = validRequest;
 
 for (let req of ["owner", "repo", "branch"]) {
   const body = { ...validRequest };
@@ -263,7 +263,7 @@ test('success (branch exists - discard deletions and retry on failure) - file de
   const changes = [{
     message: "This is the second commit",
     filesToDelete: ['wow-this-file-disappeared'],
-    retryOnDeleteFailure: true,
+    ignoreDeletionFailures: true,
     files: {
       'wow-this-file-didnt': {
         contents: 'hi',
@@ -291,7 +291,7 @@ test('success (branch exists - throw and return on failure) - file deletions and
   const changes = [{
     message: "Hello there",
     filesToDelete: ['wow-this-file-disappeared'],
-    retryOnDeleteFailure: false,
+    ignoreDeletionFailures: false,
     files: {
       'wow-this-file-didnt': {
         contents: 'hi',
@@ -467,11 +467,6 @@ function mockCreateTreeWithDelete(baseTree) {
     expectedBody
   );
 
-  const m2 = nock("https://api.github.com").post(
-    `/repos/${owner}/${repo}/git/trees`,
-    expectedBody
-  );
-
   const body = {
     sha: "fffff6bbf5ab983d31b1cca28e204b71ab722764"
   };
@@ -580,7 +575,7 @@ function mockCreateRefSecond(branch, sha) {
   m.reply(200);
 }
 
-function mockGetRepo(defaultBranch) {
+function mockGetRepo() {
   const body = {
     default_branch: "master"
   };

--- a/create-or-update-files.test.js
+++ b/create-or-update-files.test.js
@@ -23,11 +23,11 @@ const validRequest = {
 
 I hope it works`,
         "test2.md": {
-          contents: `Something else`
-        }
-      }
-    }
-  ]
+          contents: `Something else`,
+        },
+      },
+    },
+  ],
 };
 
 // Destructuring for easier access later
@@ -82,10 +82,10 @@ test(`no commit message`, async () => {
     changes: [
       {
         files: {
-          "test.md": null
-        }
-      }
-    ]
+          "test.md": null,
+        },
+      },
+    ],
   };
   await expect(run(body)).rejects.toEqual(
     `changes[].message is a required parameter`
@@ -100,7 +100,7 @@ test(`no files provided (empty object)`, async () => {
 
   const body = {
     ...validRequest,
-    changes: [{ message: "Test Commit", files: {} }]
+    changes: [{ message: "Test Commit", files: {} }],
   };
   await expect(run(body)).rejects.toEqual(
     `either changes[].files or changes[].filesToDelete are required`
@@ -131,10 +131,10 @@ test(`no file contents provided`, async () => {
       {
         message: "This is a test",
         files: {
-          "test.md": null
-        }
-      }
-    ]
+          "test.md": null,
+        },
+      },
+    ],
   };
   await expect(run(body)).rejects.toEqual(
     `No file contents provided for test.md`
@@ -151,11 +151,11 @@ test(`success (submodule, branch exists)`, async () => {
           my_submodule: {
             contents: "new-submodule-sha",
             mode: "160000",
-            type: "commit"
-          }
-        }
-      }
-    ]
+            type: "commit",
+          },
+        },
+      },
+    ],
   };
 
   mockGetRef(branch, `sha-${branch}`, true);
@@ -168,7 +168,7 @@ test(`success (submodule, branch exists)`, async () => {
 
 test(`success (branch exists)`, async () => {
   const body = {
-    ...validRequest
+    ...validRequest,
   };
   mockGetRef(branch, `sha-${branch}`, true);
   mockCreateBlobFileOne();
@@ -183,7 +183,7 @@ test(`success (branch exists)`, async () => {
 test(`success (createBranch, base provided)`, async () => {
   const body = {
     ...validRequest,
-    createBranch: true
+    createBranch: true,
   };
   mockGetRef(branch, `sha-${branch}`, false);
   mockGetRef(base, `sha-${base}`, true);
@@ -199,7 +199,7 @@ test(`success (createBranch, base provided)`, async () => {
 test(`success (createBranch, use default base branch)`, async () => {
   const body = {
     ...validRequest,
-    createBranch: true
+    createBranch: true,
   };
   delete body.base;
 
@@ -220,14 +220,14 @@ test(`success (createBranch, use default base branch)`, async () => {
 test(`success (createBranch, use default base branch, multiple commits)`, async () => {
   const body = {
     ...validRequest,
-    createBranch: true
+    createBranch: true,
   };
 
   body.changes.push({
     message: "This is the second commit",
     files: {
-      "second.md": "With some contents"
-    }
+      "second.md": "With some contents",
+    },
   });
   delete body.base;
 
@@ -249,7 +249,7 @@ test(`success (createBranch, use default base branch, multiple commits)`, async 
   await expect(run(body)).resolves.toEqual(branch);
 });
 
-test('success (branch exists - discard deletions and retry on failure) - file deletions and updates', async () => {
+test("success (branch exists - discard deletions and retry on failure) - file deletions and updates", async () => {
   mockGetRef(branch, `sha-${branch}`, false);
   mockGetRef(base, `sha-${base}`, true);
   mockCreateBlobFileTwo();
@@ -260,26 +260,28 @@ test('success (branch exists - discard deletions and retry on failure) - file de
   mockCommitSecond(`sha-${base}`);
   mockCreateRefSecond(branch);
 
-  const changes = [{
-    message: "This is the second commit",
-    filesToDelete: ['wow-this-file-disappeared'],
-    ignoreDeletionFailures: true,
-    files: {
-      'wow-this-file-didnt': {
-        contents: 'hi',
-      }
-    }
-  }];
+  const changes = [
+    {
+      message: "This is the second commit",
+      filesToDelete: ["wow-this-file-disappeared"],
+      ignoreDeletionFailures: true,
+      files: {
+        "wow-this-file-didnt": {
+          contents: "hi",
+        },
+      },
+    },
+  ];
 
   const body = {
     ...validRequest,
     changes,
-  }
+  };
 
   await expect(run(body)).resolves.toEqual(branch);
-})
+});
 
-test('success (branch exists - throw and return on failure) - file deletions and updates', async () => {
+test("success (branch exists - throw and return on failure) - file deletions and updates", async () => {
   mockGetRef(branch, `sha-${branch}`, false);
   mockGetRef(base, `sha-${base}`, true);
   mockCreateBlobFileTwo();
@@ -288,24 +290,28 @@ test('success (branch exists - throw and return on failure) - file deletions and
   mockCommit(`sha-${base}`);
   mockCreateRef(branch);
 
-  const changes = [{
-    message: "Hello there",
-    filesToDelete: ['wow-this-file-disappeared'],
-    ignoreDeletionFailures: false,
-    files: {
-      'wow-this-file-didnt': {
-        contents: 'hi',
-      }
-    }
-  }];
+  const changes = [
+    {
+      message: "Hello there",
+      filesToDelete: ["wow-this-file-disappeared"],
+      ignoreDeletionFailures: false,
+      files: {
+        "wow-this-file-didnt": {
+          contents: "hi",
+        },
+      },
+    },
+  ];
 
   const body = {
     ...validRequest,
     changes,
-  }
+  };
 
-  await expect(run(body)).rejects.toEqual('At least one file set for deletion could not be found in repo');
-})
+  await expect(run(body)).rejects.toEqual(
+    "The file wow-this-file-disappeared could not be found in the repo"
+  );
+});
 
 function mockGetRef(branch, sha, success) {
   const m = nock("https://api.github.com").get(
@@ -314,8 +320,8 @@ function mockGetRef(branch, sha, success) {
 
   const body = {
     object: {
-      sha: sha
-    }
+      sha: sha,
+    },
   };
 
   if (success) {
@@ -334,7 +340,7 @@ function mockCreateBlob(content, sha) {
 
   const body = {
     sha: sha,
-    url: `https://api.github.com/repos/mheap/action-test/git/blobs/${sha}`
+    url: `https://api.github.com/repos/mheap/action-test/git/blobs/${sha}`,
   };
 
   m.reply(200, body);
@@ -362,10 +368,7 @@ function mockCreateBlobFileThree() {
 }
 
 function mockCreateBlobFileFour() {
-  return mockCreateBlob(
-    "aGk=",
-    "f65b65200aea4fecbe0db6ddac1c0848cdda1d9b"
-  );
+  return mockCreateBlob("aGk=", "f65b65200aea4fecbe0db6ddac1c0848cdda1d9b");
 }
 
 function mockCreateTreeSubmodule(baseTree) {
@@ -375,10 +378,10 @@ function mockCreateTreeSubmodule(baseTree) {
         path: "my_submodule",
         sha: "new-submodule-sha",
         mode: "160000",
-        type: "commit"
-      }
+        type: "commit",
+      },
     ],
-    base_tree: baseTree
+    base_tree: baseTree,
   };
 
   const m = nock("https://api.github.com").post(
@@ -387,7 +390,7 @@ function mockCreateTreeSubmodule(baseTree) {
   );
 
   const body = {
-    sha: "4112258c05f8ce2b0570f1bbb1a330c0f9595ff9"
+    sha: "4112258c05f8ce2b0570f1bbb1a330c0f9595ff9",
   };
 
   m.reply(200, body);
@@ -400,16 +403,16 @@ function mockCreateTree(baseTree) {
         path: "test.md",
         sha: "afb296bb7f3e327767bdda481c4877ba4a09e02e",
         mode: "100644",
-        type: "blob"
+        type: "blob",
       },
       {
         path: "test2.md",
         sha: "a71ee6d9405fed4f6fd181c61ceb40ef10905d30",
         mode: "100644",
-        type: "blob"
-      }
+        type: "blob",
+      },
     ],
-    base_tree: baseTree
+    base_tree: baseTree,
   };
 
   const m = nock("https://api.github.com").post(
@@ -418,7 +421,7 @@ function mockCreateTree(baseTree) {
   );
 
   const body = {
-    sha: "4112258c05f8ce2b0570f1bbb1a330c0f9595ff9"
+    sha: "4112258c05f8ce2b0570f1bbb1a330c0f9595ff9",
   };
 
   m.reply(200, body);
@@ -431,10 +434,10 @@ function mockCreateTreeSecond(baseTree) {
         path: "second.md",
         sha: "f65b65200aea4fecbe0db6ddac1c0848cdda1d9b",
         mode: "100644",
-        type: "blob"
-      }
+        type: "blob",
+      },
     ],
-    base_tree: baseTree
+    base_tree: baseTree,
   };
 
   const m = nock("https://api.github.com").post(
@@ -443,7 +446,7 @@ function mockCreateTreeSecond(baseTree) {
   );
 
   const body = {
-    sha: "fffff6bbf5ab983d31b1cca28e204b71ab722764"
+    sha: "fffff6bbf5ab983d31b1cca28e204b71ab722764",
   };
 
   m.reply(200, body);
@@ -456,10 +459,10 @@ function mockCreateTreeWithDelete(baseTree) {
         path: "wow-this-file-didnt",
         sha: "f65b65200aea4fecbe0db6ddac1c0848cdda1d9b",
         mode: "100644",
-        type: "blob"
-      }
+        type: "blob",
+      },
     ],
-    base_tree: baseTree
+    base_tree: baseTree,
   };
 
   const m = nock("https://api.github.com").post(
@@ -468,7 +471,7 @@ function mockCreateTreeWithDelete(baseTree) {
   );
 
   const body = {
-    sha: "fffff6bbf5ab983d31b1cca28e204b71ab722764"
+    sha: "fffff6bbf5ab983d31b1cca28e204b71ab722764",
   };
 
   m.reply(200, body);
@@ -478,7 +481,7 @@ function mockCommitSubmodule(baseTree) {
   const expectedBody = {
     message: "Your submodule commit message",
     tree: "4112258c05f8ce2b0570f1bbb1a330c0f9595ff9",
-    parents: [baseTree]
+    parents: [baseTree],
   };
 
   const m = nock("https://api.github.com").post(
@@ -487,7 +490,7 @@ function mockCommitSubmodule(baseTree) {
   );
 
   const body = {
-    sha: "ef105a72c03ce2743d90944c2977b1b5563b43c0"
+    sha: "ef105a72c03ce2743d90944c2977b1b5563b43c0",
   };
 
   m.reply(200, body);
@@ -497,7 +500,7 @@ function mockCommit(baseTree) {
   const expectedBody = {
     message: "Your commit message",
     tree: "4112258c05f8ce2b0570f1bbb1a330c0f9595ff9",
-    parents: [baseTree]
+    parents: [baseTree],
   };
 
   const m = nock("https://api.github.com").post(
@@ -506,7 +509,7 @@ function mockCommit(baseTree) {
   );
 
   const body = {
-    sha: "ef105a72c03ce2743d90944c2977b1b5563b43c0"
+    sha: "ef105a72c03ce2743d90944c2977b1b5563b43c0",
   };
 
   m.reply(200, body);
@@ -516,7 +519,7 @@ function mockCommitSecond(baseTree) {
   const expectedBody = {
     message: "This is the second commit",
     tree: "fffff6bbf5ab983d31b1cca28e204b71ab722764",
-    parents: [baseTree]
+    parents: [baseTree],
   };
 
   const m = nock("https://api.github.com").post(
@@ -525,7 +528,7 @@ function mockCommitSecond(baseTree) {
   );
 
   const body = {
-    sha: "45d77edc93556e3a997bf73d5ed4d9fb57068928"
+    sha: "45d77edc93556e3a997bf73d5ed4d9fb57068928",
   };
 
   m.reply(200, body);
@@ -534,7 +537,7 @@ function mockCommitSecond(baseTree) {
 function mockUpdateRef(branch) {
   const expectedBody = {
     force: true,
-    sha: "ef105a72c03ce2743d90944c2977b1b5563b43c0"
+    sha: "ef105a72c03ce2743d90944c2977b1b5563b43c0",
   };
 
   const m = nock("https://api.github.com").patch(
@@ -549,7 +552,7 @@ function mockCreateRef(branch, sha) {
   const expectedBody = {
     force: true,
     ref: `refs/heads/${branch}`,
-    sha: sha || "ef105a72c03ce2743d90944c2977b1b5563b43c0"
+    sha: sha || "ef105a72c03ce2743d90944c2977b1b5563b43c0",
   };
 
   const m = nock("https://api.github.com").post(
@@ -564,7 +567,7 @@ function mockCreateRefSecond(branch, sha) {
   const expectedBody = {
     force: true,
     ref: `refs/heads/${branch}`,
-    sha: sha || "45d77edc93556e3a997bf73d5ed4d9fb57068928"
+    sha: sha || "45d77edc93556e3a997bf73d5ed4d9fb57068928",
   };
 
   const m = nock("https://api.github.com").post(
@@ -577,7 +580,7 @@ function mockCreateRefSecond(branch, sha) {
 
 function mockGetRepo() {
   const body = {
-    default_branch: "master"
+    default_branch: "master",
   };
 
   nock("https://api.github.com")

--- a/create-or-update-files.test.js
+++ b/create-or-update-files.test.js
@@ -103,7 +103,7 @@ test(`no files provided (empty object)`, async () => {
     changes: [{ message: "Test Commit", files: {} }]
   };
   await expect(run(body)).rejects.toEqual(
-    `changes[].files is a required parameter`
+    `either changes[].files or changes[].filesToDelete are required`
   );
 });
 
@@ -115,7 +115,7 @@ test(`no files provided (missing object)`, async () => {
 
   const body = { ...validRequest, changes: [{ message: "Test Commit" }] };
   await expect(run(body)).rejects.toEqual(
-    `changes[].files is a required parameter`
+    `either changes[].files or changes[].filesToDelete are required`
   );
 });
 


### PR DESCRIPTION
This adds the functionality of file deletions.
the API allows users to push the files into the `change.filesToDelete` array similarly to current update/creation behavior.

If the user sets `change.retryOnDeleteFailure: true`, the plugin falls back to current behavior when failing to delete.
`change.retryOnDeleteFailure` is set to false by default and the commit request will fail otherwise.

I've also done some refactoring.

[relates to this issue](https://github.com/mheap/octokit-commit-multiple-files/issues/6)

* New functionality has been tested in a live project but tests were not added yet because the test API seems to be broken.