### PR TITLE
Add support for `author` and `committer`

### DIFF
--- a/create-or-update-files.js
+++ b/create-or-update-files.js
@@ -19,6 +19,8 @@ module.exports = function(octokit, opts) {
         base,
         branch: branchName,
         createBranch,
+        committer,
+        author,
         changes
       } = opts;
 
@@ -152,6 +154,8 @@ module.exports = function(octokit, opts) {
           octokit,
           owner,
           repo,
+          committer,
+          author,
           message,
           tree,
           baseTree
@@ -203,12 +207,29 @@ async function fileExistsInRepo(octokit, owner, repo, path, branch) {
   }
 }
 
-async function createCommit(octokit, owner, repo, message, tree, baseTree) {
+async function createCommit(
+  octokit,
+  owner,
+  repo,
+  committer,
+  author,
+  message,
+  tree,
+  baseTree
+) {
   return (
     await octokit.git.createCommit({
       owner,
       repo,
       message,
+      committer: {
+        name: committer.name,
+        email: committer.email
+      },
+      author: {
+        name: author.name,
+        email: author.email
+      },
       tree: tree.sha,
       parents: [baseTree]
     })

--- a/create-or-update-files.js
+++ b/create-or-update-files.js
@@ -222,14 +222,8 @@ async function createCommit(
       owner,
       repo,
       message,
-      committer: {
-        name: committer.name,
-        email: committer.email
-      },
-      author: {
-        name: author.name,
-        email: author.email
-      },
+      committer,
+      author,
       tree: tree.sha,
       parents: [baseTree]
     })

--- a/create-or-update-files.test.js
+++ b/create-or-update-files.test.js
@@ -180,6 +180,48 @@ test(`success (branch exists)`, async () => {
   await expect(run(body)).resolves.toEqual(branch);
 });
 
+test(`success (committer details)`, async () => {
+  const committer = {
+    name: "Ashley Person",
+    email: "a.person@example.com"
+  };
+  const body = {
+    ...validRequest,
+    committer
+  };
+  mockGetRef(branch, `sha-${branch}`, true);
+  mockCreateBlobFileOne();
+  mockCreateBlobFileTwo();
+  mockCreateTree(`sha-${branch}`);
+  mockCommit(`sha-${branch}`, {
+    committer
+  });
+  mockUpdateRef(branch);
+
+  await expect(run(body)).resolves.toEqual(branch);
+});
+
+test(`success (author details)`, async () => {
+  const author = {
+    name: "Ashley Person",
+    email: "a.person@example.com"
+  };
+  const body = {
+    ...validRequest,
+    author
+  };
+  mockGetRef(branch, `sha-${branch}`, true);
+  mockCreateBlobFileOne();
+  mockCreateBlobFileTwo();
+  mockCreateTree(`sha-${branch}`);
+  mockCommit(`sha-${branch}`, {
+    author
+  });
+  mockUpdateRef(branch);
+
+  await expect(run(body)).resolves.toEqual(branch);
+});
+
 test(`success (createBranch, base provided)`, async () => {
   const body = {
     ...validRequest,
@@ -561,11 +603,14 @@ function mockCommitSubmodule(baseTree) {
   m.reply(200, body);
 }
 
-function mockCommit(baseTree) {
+function mockCommit(baseTree, additional) {
+  additional = additional || {};
+
   const expectedBody = {
     message: "Your commit message",
     tree: "4112258c05f8ce2b0570f1bbb1a330c0f9595ff9",
-    parents: [baseTree]
+    parents: [baseTree],
+    ...additional
   };
 
   const m = nock("https://api.github.com").post(


### PR DESCRIPTION
Add support for providing `author` and `committer` details as documented in https://octokit.github.io/rest.js/v18#git-create-commit

@lhumblot provided the initial patch, and I cleaned it up to allow for all fields to be provided (the initial patch set `name` and `email`) and added some tests

Resolves #11 