### PR TITLE
feat: introduce batched requests for async-loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,5 @@ In addition, you can set the `filesToDelete` property as an array of strings (fi
 
 ```javascript
 {
-  "batchSize" = 10
+  "batchSize": 10
 }

--- a/README.md
+++ b/README.md
@@ -104,3 +104,10 @@ In addition, you can set the `filesToDelete` property as an array of strings (fi
   "ignoreDeletionFailures": true,
 }
 ```
+
+- If `batchSize` is set, then file deletions and file uploads will use batched concurrent requests as opposed to iterating through them. This can be helpful for uploading many small files. Beware of your Github usage limits. 
+
+```javascript
+{
+  "batchSize" = 10
+}

--- a/create-or-update-files.test.js
+++ b/create-or-update-files.test.js
@@ -61,6 +61,11 @@ test(`empty parameter (changes)`, () => {
   expect(run(body)).rejects.toEqual(`No changes provided`);
 });
 
+test(`non-number batchSize (changes)`, () => {
+  const body = { ...validRequest, batchSize: "5" };
+  expect(run(body)).rejects.toEqual(`batchSize must be a number`);
+});
+
 test(`branch does not exist, createBranch false`, async () => {
   mockGetRef(branch, `sha-${branch}`, false);
   const body = { ...validRequest, createBranch: false };


### PR DESCRIPTION
@mheap 

Hey there, I've been using the plugin to automate translating UI resource files and committing back the translated versions. I'm committing back ~30-50 small files and I've found the need to batch the section on `createBlob`. For completeness, I've also done the same with the other await-loop surrounding `fileExistsInRepo` for deleting files.

What's been done:
- Introduced a new parameter `batchSize`, defaulting to `n = 1`.
- Given a `batchSize`, split the change parameters into `n` concurrent requests, and map-and-await them using the existing implementation via `Promise.all`.
- Test for parameter validation.
- Readme section for use.