### PR TITLE
Return `base`

### DIFF
--- a/create-or-update-files.js
+++ b/create-or-update-files.js
@@ -208,7 +208,7 @@ module.exports = function (octokit, opts) {
 
       // Return the new branch name so that we can use it later
       // e.g. to create a pull request
-      return resolve({ commits });
+      return resolve({ commits, base });
     } catch (e) {
       return reject(e);
     }


### PR DESCRIPTION
This PR includes `base` branch in the returned object, which is generated if not passed to options. 

This is needed to be used later in a PR; you have this as a comment, but did not return the property (regression?). 

Unless I am missing something obvious, the returned `commits` does not include the base branch name?