### PR TITLE
Move createOrUpdateFiles to the root object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Octokit = Octokit.plugin(require("octokit-commit-multiple-files"));
 
 const octokit = new Octokit();
 
-const commits = await octokit.rest.repos.createOrUpdateFiles({
+const commits = await octokit.createOrUpdateFiles({
   owner,
   repo,
   branch,
@@ -52,7 +52,7 @@ I hope it works`,
 If you want to upload non-text data, you can `base64`` encode the content and provide that as the value. Here's an example that would upload a small GitHub icon to a repository:
 
 ```javascript
-const commits = await octokit.rest.repos.createOrUpdateFiles({
+const commits = await octokit.createOrUpdateFiles({
   owner,
   repo,
   branch,

--- a/create-or-update-files.test.js
+++ b/create-or-update-files.test.js
@@ -432,7 +432,7 @@ test("failure (fileToDelete is missing)", async () => {
 test("Loads plugin", () => {
   const TestOctokit = Octokit.plugin(require("."));
   const testOctokit = new TestOctokit();
-  expect(testOctokit).toHaveProperty("rest.repos.createOrUpdateFiles");
+  expect(testOctokit).toHaveProperty("createOrUpdateFiles");
 });
 
 test("Does not overwrite other methods", () => {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const plugin = require("./create-or-update-files");
 
 module.exports = function (octokit) {
-  octokit.rest.repos.createOrUpdateFiles = plugin.bind(null, octokit);
+  return {
+    createOrUpdateFiles: plugin.bind(null, octokit),
+  };
 };


### PR DESCRIPTION
Adds compatibility with `@octokit/rest v19.0.7`+

It is no longer possible to add methods to `octokit.rest.repos` (via https://github.com/octokit/plugin-rest-endpoint-methods.js/issues/668)

Resolves #110 