### PR TITLE
Fix function isBase64

### DIFF
--- a/create-or-update-files.js
+++ b/create-or-update-files.js
@@ -1,4 +1,32 @@
-const isBase64 = require("is-base64");
+function isBase64(str) {
+  var notBase64 = /[^A-Z0-9+\/=]/i;
+  const isString = (typeof str === 'string' || str instanceof String);
+
+  if (!isString) {
+    let invalidType;
+    if (str === null) {
+      invalidType = 'null';
+    } else {
+      invalidType = typeof str;
+      if (invalidType === 'object' && str.constructor && str.constructor.hasOwnProperty('name')) {
+        invalidType = str.constructor.name;
+      } else {
+        invalidType = `a ${invalidType}`;
+      }
+    }
+    throw new TypeError(`Expected string but received ${invalidType}.`);
+  }
+
+  const len = str.length;
+  if (!len || len % 4 !== 0 || notBase64.test(str)) {
+    return false;
+  }
+  const firstPaddingChar = str.indexOf('=');
+  return firstPaddingChar === -1 ||
+    firstPaddingChar === len - 1 ||
+    (firstPaddingChar === len - 2 && str[len - 1] === '=');
+}
+
 module.exports = function (octokit, opts) {
   return new Promise(async (resolve, reject) => {
     // Up front validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "octokit-commit-multiple-files",
       "version": "5.0.0",
       "license": "MIT",
-      "dependencies": {
-        "is-base64": "^1.1.0"
-      },
       "devDependencies": {
         "@octokit/rest": ">=18.5.0",
         "eslint": "^8.47.0",
@@ -2877,15 +2874,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
-    },
-    "node_modules/is-base64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-1.1.0.tgz",
-      "integrity": "sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g==",
-      "bin": {
-        "is_base64": "bin/is-base64",
-        "is-base64": "bin/is-base64"
-      }
     },
     "node_modules/is-core-module": {
       "version": "2.13.0",
@@ -7199,11 +7187,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
-    },
-    "is-base64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-1.1.0.tgz",
-      "integrity": "sha512-Nlhg7Z2dVC4/PTvIFkgVVNvPHSO2eR/Yd0XzhGiXCXEvWnptXlXa/clQ8aePPiMuxEGcWfzWbGw2Fe3d+Y3v1g=="
     },
     "is-core-module": {
       "version": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "nock": "^13.3.3"
   },
   "dependencies": {
-    "is-base64": "^1.1.0"
   },
   "peerDependencies": {
     "@octokit/rest": ">=20.0.1"


### PR DESCRIPTION
Hello. Thank you for maintaining the library.

## Environment
"octokit-commit-multiple-files": "^5.0.0",

## Issue
When uploading an image, if the size of the base64 exceeds 5MB, the error `Maximum call stack size exceeded` occurs.

## Changes
I found the solution [here](https://github.com/webdriverio/webdriverio/issues/5208) . It was an issue with the `isBase64` library, and changing that function resolved the issue.

## Log
```
Error creating commit: RangeError: Maximum call stack size exceeded
    at RegExp.test (<anonymous>)
    at isBase64 (webpack-internal:///(action-browser)/./node_modules/is-base64/is-base64.js:24:52)
    at createBlob (webpack-internal:///(action-browser)/./node_modules/octokit-commit-multiple-files/create-or-update-files.js:181:14)
    at eval (webpack-internal:///(action-browser)/./node_modules/octokit-commit-multiple-files/create-or-update-files.js:95:47)
    at Array.map (<anonymous>)
    at eval (webpack-internal:///(action-browser)/./node_modules/octokit-commit-multiple-files/create-or-update-files.js:87:45)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
Error creating commit: Maximum call stack size exceeded
```